### PR TITLE
Use same build tools as main app so that build passes on ci

### DIFF
--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "29.0.0"
+    buildToolsVersion '28.0.3'
 
 
     defaultConfig {


### PR DESCRIPTION
Our ci machines don't have build tools 29 enabled, and our main app uses build tools 28.3.0.  Let's stay with build tools 28 until we are ready to update ci.