### PR TITLE
Make 0x prefix optional for valid hex string

### DIFF
--- a/android/core/src/main/java/com/coinbase/wallet/core/extensions/String+Core.kt
+++ b/android/core/src/main/java/com/coinbase/wallet/core/extensions/String+Core.kt
@@ -12,7 +12,7 @@ private const val hexadecimalCharacters = "0123456789abcdef"
  */
 val String.isHexString: Boolean
     get() = try {
-        Regex("^(0x|0X)[a-f0-9]*$", RegexOption.IGNORE_CASE).matches(this)
+        Regex("^(0x|0X)?[a-f0-9]*$", RegexOption.IGNORE_CASE).matches(this)
     } catch (e: Exception) {
         false
     }


### PR DESCRIPTION
### *Pivotal Tracker Story ID*
https://www.pivotaltracker.com/story/show/171437274

### *What changed? Why?*
Make 0x prefix optional to be a valid hex string in regex 

### *How has it been tested?*
<!-- Note: Check off all the sourced you tested this on after you've created the PR -->

### *Screenshots*
<!-- Feel free to delete this section if screenshots are not applicable -->