### PR TITLE
Cherry pick Jake Wharton's Replaying Share into Core

### DIFF
--- a/android/core/src/main/java/com/coinbase/wallet/core/extensions/Observable+Core.kt
+++ b/android/core/src/main/java/com/coinbase/wallet/core/extensions/Observable+Core.kt
@@ -1,6 +1,7 @@
 package com.coinbase.wallet.core.extensions
 
 import com.coinbase.wallet.core.util.Optional
+import com.coinbase.wallet.core.util.ReplayingShare
 import io.reactivex.Observable
 import io.reactivex.Single
 
@@ -56,4 +57,20 @@ fun <T> Observable<T>.retryIfNeeded(maxAttempts: Int, shouldRetry: (Throwable) -
  */
 fun <T> Observable<T>.asUnit(): Observable<Unit> {
     return this.map { Unit }
+}
+
+/**
+ * A transformer which combines `replay(1)`, `publish()`, and `refCount()` operators.
+ *
+ * Unlike traditional combinations of these operators, `ReplayingShare` caches the last emitted
+ * value from the upstream observable *only* when one or more downstream observers are connected.
+ * This allows expensive upstream observables to be shut down when no one is observing while also
+ * replaying the last value seen by *any* observer to new ones.
+ *
+ * @param defaultValue the initial value delivered to new subscribers before any events are cached.
+ * A null value means there will be no initial emission.
+ */
+@JvmOverloads
+fun <T> Observable<T>.replayingShare(defaultValue: T? = null): Observable<T> {
+    return compose(ReplayingShare.create(defaultValue))
 }

--- a/android/core/src/main/java/com/coinbase/wallet/core/util/ReplayingShare.kt
+++ b/android/core/src/main/java/com/coinbase/wallet/core/util/ReplayingShare.kt
@@ -1,0 +1,181 @@
+package com.coinbase.wallet.core.util
+
+
+import io.reactivex.Flowable
+import io.reactivex.FlowableTransformer
+import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
+import io.reactivex.Observer
+import io.reactivex.annotations.NonNull
+import io.reactivex.annotations.Nullable
+import io.reactivex.disposables.Disposable
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+
+/**
+ * This class is taken from Jake Wharton's ReplayingShare library (https://github.com/JakeWharton/RxReplayingShare)
+ * It has been adapted for Kotlin.  The reason we don't import this library directly is that it doesn't support
+ * RxJava3 and we don't want to pin ourselves to RxJava2.
+ *
+ * A transformer which combines the `replay(1)`, `publish()`, and `refCount()`
+ * operators.
+ *
+ *
+ * Unlike traditional combinations of these operators, `ReplayingShare` caches the last emitted
+ * value from the upstream observable or flowable *only* when one or more downstream subscribers
+ * are connected. This allows expensive upstream sources to be shut down when no one is listening
+ * while also replaying the last value seen by *any* subscriber to new ones.
+ */
+class ReplayingShare<T> private constructor(
+    @param:Nullable @field:Nullable private val defaultValue: T?
+) : ObservableTransformer<T, T>, FlowableTransformer<T, T> {
+
+    override fun apply(upstream: Observable<T>): Observable<T> {
+        val lastSeen = LastSeen(defaultValue)
+        return LastSeenObservable(upstream.doOnEach(lastSeen).share(), lastSeen).hide()
+    }
+
+    override fun apply(upstream: Flowable<T>): Flowable<T> {
+        val lastSeen = LastSeen(defaultValue)
+        return LastSeenFlowable(upstream.doOnEach(lastSeen).share(), lastSeen).hide()
+    }
+
+    internal class LastSeen<T>(
+        @param:Nullable @field:Nullable private val defaultValue: T
+    ) : Observer<T>, Subscriber<T> {
+        @Nullable
+        @Volatile
+        internal var value: T? = defaultValue
+
+        override fun onNext(value: T) {
+            this.value = value
+        }
+
+        override fun onError(e: Throwable) {
+            value = defaultValue
+        }
+
+        override fun onComplete() {
+            value = defaultValue
+        }
+
+        override fun onSubscribe(ignored: Subscription) {}
+        override fun onSubscribe(ignored: Disposable) {}
+    }
+
+    internal class LastSeenObservable<T>(
+        private val upstream: Observable<T>,
+        private val lastSeen: LastSeen<T>
+    ) : Observable<T>() {
+
+        override fun subscribeActual(observer: Observer<in T>) {
+            upstream.subscribe(LastSeenObserver(observer, lastSeen))
+        }
+    }
+
+    internal class LastSeenObserver<T>(
+        private val downstream: Observer<in T>,
+        private val lastSeen: LastSeen<T>
+    ) : Observer<T> {
+
+        override fun onSubscribe(d: Disposable) {
+            downstream.onSubscribe(d)
+
+            val value = lastSeen.value
+            if (value != null && !d.isDisposed) {
+                downstream.onNext(value)
+            }
+        }
+
+        override fun onNext(value: T) {
+            downstream.onNext(value)
+        }
+
+        override fun onComplete() {
+            downstream.onComplete()
+        }
+
+        override fun onError(e: Throwable) {
+            downstream.onError(e)
+        }
+    }
+
+    internal class LastSeenFlowable<T>(
+        private val upstream: Flowable<T>,
+        private val lastSeen: LastSeen<T>
+    ) : Flowable<T>() {
+
+        override fun subscribeActual(subscriber: Subscriber<in T>) {
+            upstream.subscribe(LastSeenSubscriber(subscriber, lastSeen))
+        }
+    }
+
+    internal class LastSeenSubscriber<T>(
+        private val downstream: Subscriber<in T>,
+        private val lastSeen: LastSeen<T>
+    ) : Subscriber<T>, Subscription {
+        private var subscription: Subscription? = null
+
+        @Volatile
+        private var cancelled: Boolean = false
+
+        private var first = true
+
+        override fun onSubscribe(subscription: Subscription) {
+            this.subscription = subscription
+            downstream.onSubscribe(this)
+        }
+
+        override fun request(amountInput: Long) {
+            var amount = amountInput
+            if (amount == 0L) return
+
+            if (first) {
+                first = false
+
+                val value = lastSeen.value
+                if (value != null && !cancelled) {
+                    downstream.onNext(value)
+
+                    if (amount != java.lang.Long.MAX_VALUE && --amount == 0L) {
+                        return
+                    }
+                }
+            }
+            val subscription = this.subscription!!
+            subscription.request(amount)
+        }
+
+        override fun cancel() {
+            val subscription = this.subscription!!
+            cancelled = true
+            subscription.cancel()
+        }
+
+        override fun onNext(value: T) {
+            downstream.onNext(value)
+        }
+
+        override fun onComplete() {
+            downstream.onComplete()
+        }
+
+        override fun onError(t: Throwable) {
+            downstream.onError(t)
+        }
+    }
+
+    companion object {
+        /**
+         * Creates a `ReplayingShare` transformer with a default value or null which will be emitted downstream
+         * on subscription if there is not any cached value yet.
+         *
+         * @param defaultValue the initial value delivered to new subscribers before any events are
+         * cached.
+         */
+        @NonNull
+        fun <T> create(defaultValue: T? = null): ReplayingShare<T> {
+            return ReplayingShare(defaultValue)
+        }
+    }
+}

--- a/android/core/src/main/java/com/coinbase/wallet/core/util/ReplayingShare.kt
+++ b/android/core/src/main/java/com/coinbase/wallet/core/util/ReplayingShare.kt
@@ -1,6 +1,5 @@
 package com.coinbase.wallet.core.util
 
-
 import io.reactivex.Flowable
 import io.reactivex.FlowableTransformer
 import io.reactivex.Observable

--- a/android/core/src/test/java/com/coinbase/wallet/core/extensions/ObservableTests.kt
+++ b/android/core/src/test/java/com/coinbase/wallet/core/extensions/ObservableTests.kt
@@ -1,7 +1,6 @@
 package com.coinbase.wallet.core.extensions
 
 import io.reactivex.Observable
-import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
 import io.reactivex.subjects.PublishSubject
 import org.junit.Assert

--- a/android/core/src/test/java/com/coinbase/wallet/core/extensions/ObservableTests.kt
+++ b/android/core/src/test/java/com/coinbase/wallet/core/extensions/ObservableTests.kt
@@ -1,0 +1,64 @@
+package com.coinbase.wallet.core.extensions
+
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.subjects.PublishSubject
+import org.junit.Assert
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+class ObservableTests {
+    @Test
+    fun replaySharedCreatesOnce() {
+        val createCount = AtomicInteger(0)
+        val subject = PublishSubject.create<Unit>()
+
+        val observable = subject
+            .map { createCount.incrementAndGet() }
+            .replayingShare()
+
+        val countdownLatch = CountDownLatch(2)
+        observable.subscribeBy {
+            Assert.assertEquals(1, it)
+            countdownLatch.countDown()
+        }
+
+        observable.subscribeBy {
+            Assert.assertEquals(1, it)
+            countdownLatch.countDown()
+        }
+
+        subject.onNext(Unit)
+
+        countdownLatch.await()
+    }
+
+    @Test
+    fun replaySharedCreatesAgainAfterUnsubscribe() {
+        val createCount = AtomicInteger(0)
+        val observable = Observable.just(1)
+            .map { createCount.incrementAndGet() }
+            .replayingShare()
+
+        val countdownLatch = CountDownLatch(2)
+        observable
+            .doOnComplete { countdownLatch.countDown() }
+            .subscribeBy {
+                Assert.assertEquals(1, it)
+                countdownLatch.countDown()
+            }
+
+        countdownLatch.await()
+
+        val countdownLatch2 = CountDownLatch(1)
+
+        observable.subscribeBy {
+            Assert.assertEquals(2, it)
+            countdownLatch2.countDown()
+        }
+
+        countdownLatch2.await()
+    }
+}


### PR DESCRIPTION
To be able to share an observable and replay the last value (as long as there is a subscribe to it).  This cherry-picks over Jake Wharton's implementation - converts it to Kotlin and only extends Observable.

The reason for cherry-picking vs just importing the library is that we will be moving to RxJava3 soon and the library only supports RxJava 2.