### PR TITLE
Fix hex encoding for latest version of Xcode

### DIFF
--- a/ios/CBCore.xcodeproj/project.pbxproj
+++ b/ios/CBCore.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		24F0E407D1522F556727305B /* Pods_CBCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48766EC05FAB2D444FDAA4A7 /* Pods_CBCore.framework */; };
+		AB5D23B0243555B4005C6477 /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5D23AF243555B4005C6477 /* DataExtensionTests.swift */; };
 		D2DA735369E5DC60CA95D750 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6D7763E25565E58F813DD4A /* Pods_Tests.framework */; };
 		D3685C6D2363753A00E05516 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3685C6C2363753A00E05516 /* StringExtensionTests.swift */; };
 		E745727123EA010900DF8FA2 /* BidirectionalCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745727023EA010900DF8FA2 /* BidirectionalCollectionTests.swift */; };
@@ -65,6 +66,7 @@
 		5C49629E5827F04530A7F197 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		9BA62533429E43A054DA90E2 /* Pods-CBCoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CBCoreTests.release.xcconfig"; path = "Target Support Files/Pods-CBCoreTests/Pods-CBCoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		A6D7763E25565E58F813DD4A /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB5D23AF243555B4005C6477 /* DataExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensionTests.swift; sourceTree = "<group>"; };
 		C2D1E42FE3E279C9FFA4A53C /* Pods-CBCore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CBCore.debug.xcconfig"; path = "Target Support Files/Pods-CBCore/Pods-CBCore.debug.xcconfig"; sourceTree = "<group>"; };
 		D3685C6C2363753A00E05516 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		E5176A96504EBB3B4AA9CD75 /* Pods-CBCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CBCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-CBCoreTests/Pods-CBCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				E7A5B41822F2385C005E620F /* ArrayExtension.swift */,
 				D3685C6C2363753A00E05516 /* StringExtensionTests.swift */,
 				E745727023EA010900DF8FA2 /* BidirectionalCollectionTests.swift */,
+				AB5D23AF243555B4005C6477 /* DataExtensionTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -489,6 +492,7 @@
 				E745727123EA010900DF8FA2 /* BidirectionalCollectionTests.swift in Sources */,
 				D3685C6D2363753A00E05516 /* StringExtensionTests.swift in Sources */,
 				E76C14CC22EF6F2800E46589 /* AtomicInt32Tests.swift in Sources */,
+				AB5D23B0243555B4005C6477 /* DataExtensionTests.swift in Sources */,
 				E76C14CE22EF8F0400E46589 /* BigIntExtensionTests.swift in Sources */,
 				E76C14CB22EF6F2800E46589 /* BoundedSetTests.swift in Sources */,
 			);

--- a/ios/Source/Extensions/Data+Core.swift
+++ b/ios/Source/Extensions/Data+Core.swift
@@ -36,31 +36,37 @@ extension Data {
         return Data(randomBytes)
     }
 
-    /// Convert to prefixed hex string
-    public func toPrefixedHexString() -> String {
+    /// Convert to hex encoded string
+    public func hexEncodedString(addPrefix: Bool = false) -> String {
+        let emptyResult = addPrefix ? "0x" : ""
+
         if isEmpty {
-            return "0x"
+            return emptyResult
         }
 
-        let startIndex = 2
-        let outputLength = count * 2 + startIndex + 1
+        let startIndex = addPrefix ? 2 : 0
+        let length = count * 2 + startIndex
+        var bytes = [UInt8](repeating: 0, count: length)
 
-        return withUnsafeBytes { (ptr: UnsafePointer<UInt8>) -> String in
-            let bytes = UnsafeBufferPointer<UInt8>(start: ptr, count: self.count)
-            var output = [UInt8](repeating: 0, count: outputLength)
-            output[0] = 48 // 0
-            output[1] = 120 // x
-
-            var i = startIndex
-            for b in bytes {
-                let left = Int(b / 16)
-                let right = Int(b % 16)
-                output[i] = hexadecimalArray[left]
-                output[i + 1] = hexadecimalArray[right]
-                i += 2
-            }
-            return String(cString: UnsafePointer(output))
+        if addPrefix {
+            bytes[0] = 48 // 0
+            bytes[1] = 120 // x
         }
+
+        var i = startIndex
+        for value in self {
+            let left = hexadecimalArray[Int(value / 16)]
+            let right = hexadecimalArray[Int(value % 16)]
+            bytes[i] = left
+            bytes[i + 1] = right
+            i += 2
+        }
+
+        guard let result = String(bytes: bytes, encoding: .utf8) else {
+            return emptyResult
+        }
+
+        return result
     }
 
     /// Get a subset data from the current data using the given range

--- a/ios/Tests/DataExtensionTests.swift
+++ b/ios/Tests/DataExtensionTests.swift
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-2020 Coinbase Inc. See LICENSE
+
+@testable import CBCore
+import Foundation
+import XCTest
+
+class DataExtensionTests: XCTestCase {
+    func testHexEncodedString() {
+        let str = "acbdef0123456789abcdef0123456789"
+        let data = Data(base64Encoded: str)!
+        XCTAssertEqual(data.hexEncodedString(addPrefix: false), "69c6dd79fd35db7e39ebbf3d69b71d79fd35db7e39ebbf3d")
+        XCTAssertEqual(data.hexEncodedString(addPrefix: true), "0x69c6dd79fd35db7e39ebbf3d69b71d79fd35db7e39ebbf3d")
+    }
+
+    func testHexEncodedStringWithEmptyData() {
+        XCTAssertEqual(Data().hexEncodedString(addPrefix: false), "")
+        XCTAssertEqual(Data().hexEncodedString(addPrefix: true), "0x")
+    }
+}


### PR DESCRIPTION
Fix for latest version of Xcode (11.4) causing a crash when calling `String(cString: ...)` -> `UnsafeMutablePointer.initialize overlapping range`